### PR TITLE
fix: Add explicit permissions for GITHUB_TOKEN in release workflow fo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: ["main"]
 
+# Add explicit permissions for the GITHUB_TOKEN
+permissions:
+  contents: write # Needed for tag creation, pushing, and releases
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
…r tag creation and releases 🔧