### PR TITLE
Add optional distributed tracing (MoonlightTracer)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonlight/moonlight-sdk",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "A privacy-focused toolkit for the Moonlight protocol on Stellar Soroban smart contracts.",
   "license": "MIT",
   "tasks": {

--- a/mod.ts
+++ b/mod.ts
@@ -35,3 +35,5 @@ export * from "./src/error/errors.ts";
 
 export * from "./src/custom-xdr/index.ts";
 export * from "./src/custom-xdr/types.ts";
+
+export * from "./src/tracing/index.ts";

--- a/src/privacy-channel/index.ts
+++ b/src/privacy-channel/index.ts
@@ -16,18 +16,21 @@ import type { xdr } from "@stellar/stellar-sdk";
 import * as E from "./error.ts";
 import type { UTXOPublicKey } from "../core/utxo-keypair-base/types.ts";
 import { Buffer } from "buffer";
+import { type MoonlightTracer, withTrace } from "../tracing/index.ts";
 
 export class PrivacyChannel {
   private _client: Contract;
   private _authId: ContractId;
   private _assetId: ContractId;
   private _networkConfig: NetworkConfig;
+  private _tracer?: MoonlightTracer;
 
   public constructor(
     networkConfig: NetworkConfig,
     channelId: ContractId,
     authId: ContractId,
     assetId: ContractId,
+    options?: { tracer?: MoonlightTracer },
   ) {
     this._networkConfig = networkConfig;
 
@@ -39,6 +42,15 @@ export class PrivacyChannel {
     this._authId = authId;
 
     this._assetId = assetId;
+
+    this._tracer = options?.tracer;
+  }
+
+  /**
+   * Returns the tracer instance if set, otherwise undefined.
+   */
+  public getTracer(): MoonlightTracer | undefined {
+    return this._tracer;
   }
 
   //==========================================
@@ -179,9 +191,12 @@ export class PrivacyChannel {
     method: M;
     methodArgs: ChannelRead[M]["input"];
   }): Promise<ChannelRead[M]["output"]> {
-    return (await this.getClient().read(args)) as Promise<
-      ChannelRead[M]["output"]
-    >;
+    return withTrace(this._tracer, `PrivacyChannel.read`, async (span) => {
+      span.addEvent("calling_contract_read", { "contract.method": args.method });
+      const result = (await this.getClient().read(args)) as ChannelRead[M]["output"];
+      span.addEvent("read_complete");
+      return result;
+    }, { "contract.method": args.method });
   }
 
   /**
@@ -198,7 +213,12 @@ export class PrivacyChannel {
     auth?: xdr.SorobanAuthorizationEntry[];
     config: TransactionConfig;
   }): Promise<ReturnType<Contract["invoke"]>> {
-    return await this.getClient().invoke(args);
+    return withTrace(this._tracer, `PrivacyChannel.invoke`, async (span) => {
+      span.addEvent("calling_contract_invoke", { "contract.method": args.method });
+      const result = await this.getClient().invoke(args);
+      span.addEvent("invoke_complete");
+      return result;
+    }, { "contract.method": args.method });
   }
 
   /**
@@ -220,6 +240,13 @@ export class PrivacyChannel {
     };
     config: TransactionConfig;
   }): Promise<ReturnType<Contract["invoke"]>> {
-    return await this.getClient().invokeRaw(args);
+    return withTrace(this._tracer, `PrivacyChannel.invokeRaw`, async (span) => {
+      span.addEvent("calling_contract_invoke_raw", {
+        "contract.function": args.operationArgs.function,
+      });
+      const result = await this.getClient().invokeRaw(args);
+      span.addEvent("invoke_raw_complete");
+      return result;
+    }, { "contract.function": args.operationArgs.function });
   }
 }

--- a/src/privacy-channel/index.ts
+++ b/src/privacy-channel/index.ts
@@ -191,7 +191,7 @@ export class PrivacyChannel {
     method: M;
     methodArgs: ChannelRead[M]["input"];
   }): Promise<ChannelRead[M]["output"]> {
-    return withTrace(this._tracer, `PrivacyChannel.read`, async (span) => {
+    return await withTrace(this._tracer, `PrivacyChannel.read`, async (span) => {
       span.addEvent("calling_contract_read", { "contract.method": args.method });
       const result = (await this.getClient().read(args)) as ChannelRead[M]["output"];
       span.addEvent("read_complete");
@@ -213,7 +213,7 @@ export class PrivacyChannel {
     auth?: xdr.SorobanAuthorizationEntry[];
     config: TransactionConfig;
   }): Promise<ReturnType<Contract["invoke"]>> {
-    return withTrace(this._tracer, `PrivacyChannel.invoke`, async (span) => {
+    return await withTrace(this._tracer, `PrivacyChannel.invoke`, async (span) => {
       span.addEvent("calling_contract_invoke", { "contract.method": args.method });
       const result = await this.getClient().invoke(args);
       span.addEvent("invoke_complete");
@@ -240,7 +240,7 @@ export class PrivacyChannel {
     };
     config: TransactionConfig;
   }): Promise<ReturnType<Contract["invoke"]>> {
-    return withTrace(this._tracer, `PrivacyChannel.invokeRaw`, async (span) => {
+    return await withTrace(this._tracer, `PrivacyChannel.invokeRaw`, async (span) => {
       span.addEvent("calling_contract_invoke_raw", {
         "contract.function": args.operationArgs.function,
       });

--- a/src/privacy-channel/index.unit.test.ts
+++ b/src/privacy-channel/index.unit.test.ts
@@ -1,0 +1,147 @@
+// deno-lint-ignore-file no-explicit-any
+import { assertEquals, assertExists } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { PrivacyChannel } from "./index.ts";
+import { ChannelReadMethods } from "./constants.ts";
+import type { MoonlightSpan, MoonlightTracer } from "../tracing/index.ts";
+import type { ContractId, NetworkConfig } from "@colibri/core";
+
+function createSpyTracer() {
+  const events: {
+    name: string;
+    attributes?: Record<string, string | number | boolean>;
+  }[] = [];
+  let ended = false;
+
+  const span: MoonlightSpan = {
+    addEvent(name, attributes) {
+      events.push({ name, attributes });
+    },
+    setError() {},
+    end() {
+      ended = true;
+    },
+  };
+
+  const tracer: MoonlightTracer = {
+    startSpan(_name, _attributes) {
+      return span;
+    },
+  };
+
+  return { tracer, events, isEnded: () => ended };
+}
+
+const TEST_CHANNEL_ID =
+  "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC" as ContractId;
+const TEST_AUTH_ID =
+  "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA" as ContractId;
+const TEST_ASSET_ID =
+  "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC" as ContractId;
+
+const MOCK_NETWORK_CONFIG = {
+  rpcUrl: "https://mock.rpc",
+  networkPassphrase: "Test SDF Network ; September 2015",
+} as NetworkConfig;
+
+function createChannelWithMockClient(tracer?: MoonlightTracer) {
+  const channel = new PrivacyChannel(
+    MOCK_NETWORK_CONFIG,
+    TEST_CHANNEL_ID,
+    TEST_AUTH_ID,
+    TEST_ASSET_ID,
+    tracer ? { tracer } : undefined,
+  );
+
+  // Stub the internal client to avoid network calls
+  const mockClient = {
+    read: () => Promise.resolve([100n]),
+    invoke: () => Promise.resolve({ result: "ok" }),
+    invokeRaw: () => Promise.resolve({ result: "raw" }),
+    getContractId: () => TEST_CHANNEL_ID,
+  };
+  (channel as any)._client = mockClient;
+
+  return { channel, mockClient };
+}
+
+describe("PrivacyChannel", () => {
+  describe("Tracing", () => {
+    it("should return tracer via getTracer when provided", () => {
+      const spy = createSpyTracer();
+      const { channel } = createChannelWithMockClient(spy.tracer);
+      assertExists(channel.getTracer());
+    });
+
+    it("should return undefined from getTracer when not provided", () => {
+      const { channel } = createChannelWithMockClient();
+      assertEquals(channel.getTracer(), undefined);
+    });
+
+    it("should emit tracing events on read", async () => {
+      const spy = createSpyTracer();
+      const { channel } = createChannelWithMockClient(spy.tracer);
+
+      await channel.read({
+        method: ChannelReadMethods.utxo_balances,
+        methodArgs: { utxos: [] },
+      });
+
+      const eventNames = spy.events.map((e) => e.name);
+      assertEquals(eventNames.includes("enter"), true);
+      assertEquals(eventNames.includes("calling_contract_read"), true);
+      assertEquals(eventNames.includes("read_complete"), true);
+      assertEquals(eventNames.includes("exit"), true);
+      assertEquals(spy.isEnded(), true);
+    });
+
+    it("should emit tracing events on invoke", async () => {
+      const spy = createSpyTracer();
+      const { channel } = createChannelWithMockClient(spy.tracer);
+
+      await channel.invoke({
+        method: "transact" as any,
+        methodArgs: {} as any,
+        config: {} as any,
+      });
+
+      const eventNames = spy.events.map((e) => e.name);
+      assertEquals(eventNames.includes("enter"), true);
+      assertEquals(eventNames.includes("calling_contract_invoke"), true);
+      assertEquals(eventNames.includes("invoke_complete"), true);
+      assertEquals(eventNames.includes("exit"), true);
+      assertEquals(spy.isEnded(), true);
+    });
+
+    it("should emit tracing events on invokeRaw", async () => {
+      const spy = createSpyTracer();
+      const { channel } = createChannelWithMockClient(spy.tracer);
+
+      await channel.invokeRaw({
+        operationArgs: {
+          function: "test_fn",
+          args: [],
+        },
+        config: {} as any,
+      });
+
+      const eventNames = spy.events.map((e) => e.name);
+      assertEquals(eventNames.includes("enter"), true);
+      assertEquals(eventNames.includes("calling_contract_invoke_raw"), true);
+      assertEquals(eventNames.includes("invoke_raw_complete"), true);
+      assertEquals(eventNames.includes("exit"), true);
+      assertEquals(spy.isEnded(), true);
+    });
+
+    it("should work without tracer (no tracing overhead)", async () => {
+      const { channel } = createChannelWithMockClient();
+
+      const result = await channel.read({
+        method: ChannelReadMethods.utxo_balances,
+        methodArgs: { utxos: [] },
+      });
+
+      assertExists(result);
+    });
+  });
+});

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -1,0 +1,175 @@
+/**
+ * Minimal tracing interface for opt-in instrumentation.
+ *
+ * Consumers can implement this with @opentelemetry/api, a custom logger,
+ * or any other tracing backend. The SDK never imports @opentelemetry
+ * directly — it only calls these methods when a tracer is provided.
+ *
+ * @example Using with @opentelemetry/api:
+ * ```typescript
+ * import { trace, context, SpanStatusCode } from "@opentelemetry/api";
+ *
+ * const otelTracer = trace.getTracer("my-app");
+ * const sdkTracer: MoonlightTracer = {
+ *   startSpan(name, attributes) {
+ *     const span = otelTracer.startSpan(name, { attributes });
+ *     return {
+ *       addEvent(event, attrs) { span.addEvent(event, attrs); },
+ *       setError(error) {
+ *         span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+ *         span.recordException(error);
+ *       },
+ *       end() { span.end(); },
+ *     };
+ *   },
+ *   // Enable distributed tracing (traceparent propagation on fetch):
+ *   withActiveSpan(name, fn, attributes) {
+ *     return otelTracer.startActiveSpan(name, { attributes }, (otelSpan) => {
+ *       const span = { ... }; // same as startSpan wrapper
+ *       return fn(span);
+ *     });
+ *   },
+ * };
+ *
+ * const channel = new PrivacyChannel(networkConfig, channelId, authId, assetId, {
+ *   tracer: sdkTracer,
+ * });
+ * ```
+ */
+export interface MoonlightTracer {
+  startSpan(
+    name: string,
+    attributes?: Record<string, string | number | boolean>,
+  ): MoonlightSpan;
+
+  /**
+   * Optional: wraps a function with an active span in the trace context.
+   * When implemented, enables distributed tracing — any fetch() calls
+   * inside the callback will inherit the span's trace context and
+   * propagate W3C traceparent headers automatically.
+   *
+   * If not implemented, withTrace falls back to startSpan (spans are
+   * created but not set as active context, so no trace propagation).
+   */
+  withActiveSpan?<T>(
+    name: string,
+    fn: (span: MoonlightSpan) => T,
+    attributes?: Record<string, string | number | boolean>,
+  ): T;
+}
+
+export interface MoonlightSpan {
+  addEvent(
+    name: string,
+    attributes?: Record<string, string | number | boolean>,
+  ): void;
+  setError(error: Error): void;
+  end(): void;
+}
+
+/** No-op span returned when tracing is disabled */
+const NOOP_SPAN: MoonlightSpan = {
+  addEvent() {},
+  setError() {},
+  end() {},
+};
+
+/** No-op tracer used when no tracer is provided */
+export const NOOP_TRACER: MoonlightTracer = {
+  startSpan() {
+    return NOOP_SPAN;
+  },
+};
+
+/**
+ * Wraps an async function with a span. If no tracer is provided, runs
+ * the function without overhead.
+ *
+ * When the tracer implements `withActiveSpan`, the span is set as the
+ * active context — enabling W3C traceparent propagation on fetch() calls.
+ */
+export async function withTrace<T>(
+  tracer: MoonlightTracer | undefined,
+  name: string,
+  fn: (span: MoonlightSpan) => Promise<T> | T,
+  attributes?: Record<string, string | number | boolean>,
+): Promise<T> {
+  const t = tracer ?? NOOP_TRACER;
+
+  if (t.withActiveSpan) {
+    return t.withActiveSpan(name, (span) => {
+      span.addEvent("enter");
+      const maybePromise = fn(span);
+      const promise = maybePromise instanceof Promise ? maybePromise : Promise.resolve(maybePromise);
+      return promise.then(
+        (result) => { span.addEvent("exit"); return result; },
+        (error) => {
+          span.setError(error instanceof Error ? error : new Error(String(error)));
+          span.addEvent("exit_with_error");
+          throw error;
+        },
+      ).finally(() => span.end()) as Promise<T>;
+    }, attributes) as Promise<T>;
+  }
+
+  const span = t.startSpan(name, attributes);
+  span.addEvent("enter");
+  try {
+    const result = await fn(span);
+    span.addEvent("exit");
+    return result;
+  } catch (error) {
+    span.setError(error instanceof Error ? error : new Error(String(error)));
+    span.addEvent("exit_with_error");
+    throw error;
+  } finally {
+    span.end();
+  }
+}
+
+/**
+ * Synchronous variant of withTrace. Wraps a synchronous function with
+ * a span. If no tracer is provided, runs the function without overhead.
+ *
+ * When the tracer implements `withActiveSpan`, the span is set as the
+ * active context — enabling W3C traceparent propagation on fetch() calls.
+ */
+export function withTraceSync<T>(
+  tracer: MoonlightTracer | undefined,
+  name: string,
+  fn: (span: MoonlightSpan) => T,
+  attributes?: Record<string, string | number | boolean>,
+): T {
+  const t = tracer ?? NOOP_TRACER;
+
+  if (t.withActiveSpan) {
+    return t.withActiveSpan(name, (span) => {
+      span.addEvent("enter");
+      try {
+        const result = fn(span);
+        span.addEvent("exit");
+        return result;
+      } catch (error) {
+        span.setError(error instanceof Error ? error : new Error(String(error)));
+        span.addEvent("exit_with_error");
+        throw error;
+      } finally {
+        span.end();
+      }
+    }, attributes);
+  }
+
+  const span = t.startSpan(name, attributes);
+  span.addEvent("enter");
+  try {
+    const result = fn(span);
+    span.addEvent("exit");
+    return result;
+  } catch (error) {
+    span.setError(error instanceof Error ? error : new Error(String(error)));
+    span.addEvent("exit_with_error");
+    throw error;
+  } finally {
+    span.end();
+  }
+}

--- a/src/tracing/index.unit.test.ts
+++ b/src/tracing/index.unit.test.ts
@@ -1,0 +1,259 @@
+// deno-lint-ignore-file require-await
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import {
+  type MoonlightSpan,
+  type MoonlightTracer,
+  NOOP_TRACER,
+  withTrace,
+  withTraceSync,
+} from "./index.ts";
+
+function createMockTracer() {
+  const events: { name: string; attributes?: Record<string, string | number | boolean> }[] = [];
+  const errors: Error[] = [];
+  let ended = false;
+
+  const span: MoonlightSpan = {
+    addEvent(name, attributes) {
+      events.push({ name, attributes });
+    },
+    setError(error) {
+      errors.push(error);
+    },
+    end() {
+      ended = true;
+    },
+  };
+
+  const tracer: MoonlightTracer = {
+    startSpan(_name, _attributes) {
+      return span;
+    },
+  };
+
+  return { tracer, span, events, errors, isEnded: () => ended };
+}
+
+function createMockTracerWithActiveSpan() {
+  const events: { name: string; attributes?: Record<string, string | number | boolean> }[] = [];
+  const errors: Error[] = [];
+  let ended = false;
+
+  const span: MoonlightSpan = {
+    addEvent(name, attributes) {
+      events.push({ name, attributes });
+    },
+    setError(error) {
+      errors.push(error);
+    },
+    end() {
+      ended = true;
+    },
+  };
+
+  const tracer: MoonlightTracer = {
+    startSpan(_name, _attributes) {
+      return span;
+    },
+    withActiveSpan(_name, fn, _attributes) {
+      return fn(span);
+    },
+  };
+
+  return { tracer, span, events, errors, isEnded: () => ended };
+}
+
+describe("tracing", () => {
+  describe("NOOP_TRACER", () => {
+    it("should return a span with no-op methods", () => {
+      const span = NOOP_TRACER.startSpan("test");
+      // These should not throw
+      span.addEvent("event");
+      span.setError(new Error("test"));
+      span.end();
+    });
+  });
+
+  describe("withTrace", () => {
+    it("should run fn without tracer", async () => {
+      const result = await withTrace(undefined, "op", async () => 42);
+      assertEquals(result, 42);
+    });
+
+    it("should run fn with tracer (startSpan path)", async () => {
+      const mock = createMockTracer();
+      const result = await withTrace(mock.tracer, "op", async () => "ok");
+      assertEquals(result, "ok");
+      assertEquals(mock.events[0].name, "enter");
+      assertEquals(mock.events[1].name, "exit");
+      assertEquals(mock.isEnded(), true);
+    });
+
+    it("should capture errors with tracer (startSpan path)", async () => {
+      const mock = createMockTracer();
+      await assertRejects(
+        () =>
+          withTrace(mock.tracer, "op", async () => {
+            throw new Error("boom");
+          }),
+        Error,
+        "boom",
+      );
+      assertEquals(mock.errors.length, 1);
+      assertEquals(mock.errors[0].message, "boom");
+      assertEquals(mock.events.some((e) => e.name === "exit_with_error"), true);
+      assertEquals(mock.isEnded(), true);
+    });
+
+    it("should capture non-Error throws with tracer (startSpan path)", async () => {
+      const mock = createMockTracer();
+      await assertRejects(() =>
+        withTrace(mock.tracer, "op", async () => {
+          throw "string error";
+        })
+      );
+      assertEquals(mock.errors[0].message, "string error");
+    });
+
+    it("should use withActiveSpan when available", async () => {
+      const mock = createMockTracerWithActiveSpan();
+      const result = await withTrace(mock.tracer, "op", async () => "active");
+      assertEquals(result, "active");
+      assertEquals(mock.events[0].name, "enter");
+      assertEquals(mock.events[1].name, "exit");
+      assertEquals(mock.isEnded(), true);
+    });
+
+    it("should capture errors via withActiveSpan path", async () => {
+      const mock = createMockTracerWithActiveSpan();
+      await assertRejects(
+        () =>
+          withTrace(mock.tracer, "op", async () => {
+            throw new Error("active boom");
+          }),
+        Error,
+        "active boom",
+      );
+      assertEquals(mock.errors[0].message, "active boom");
+      assertEquals(mock.events.some((e) => e.name === "exit_with_error"), true);
+      assertEquals(mock.isEnded(), true);
+    });
+
+    it("should capture non-Error throws via withActiveSpan path", async () => {
+      const mock = createMockTracerWithActiveSpan();
+      await assertRejects(() =>
+        withTrace(mock.tracer, "op", async () => {
+          throw "string error";
+        })
+      );
+      assertEquals(mock.errors[0].message, "string error");
+    });
+
+    it("should handle synchronous fn in withActiveSpan path", async () => {
+      const mock = createMockTracerWithActiveSpan();
+      const result = await withTrace(mock.tracer, "op", () => "sync-value");
+      assertEquals(result, "sync-value");
+      assertEquals(mock.isEnded(), true);
+    });
+
+    it("should pass attributes to startSpan", async () => {
+      let receivedAttrs: Record<string, string | number | boolean> | undefined;
+      const tracer: MoonlightTracer = {
+        startSpan(_name, attributes) {
+          receivedAttrs = attributes;
+          return { addEvent() {}, setError() {}, end() {} };
+        },
+      };
+      await withTrace(tracer, "op", async () => "ok", { key: "value" });
+      assertEquals(receivedAttrs, { key: "value" });
+    });
+  });
+
+  describe("withTraceSync", () => {
+    it("should run fn without tracer", () => {
+      const result = withTraceSync(undefined, "op", () => 42);
+      assertEquals(result, 42);
+    });
+
+    it("should run fn with tracer (startSpan path)", () => {
+      const mock = createMockTracer();
+      const result = withTraceSync(mock.tracer, "op", () => "ok");
+      assertEquals(result, "ok");
+      assertEquals(mock.events[0].name, "enter");
+      assertEquals(mock.events[1].name, "exit");
+      assertEquals(mock.isEnded(), true);
+    });
+
+    it("should capture errors with tracer (startSpan path)", () => {
+      const mock = createMockTracer();
+      assertThrows(
+        () =>
+          withTraceSync(mock.tracer, "op", () => {
+            throw new Error("boom");
+          }),
+        Error,
+        "boom",
+      );
+      assertEquals(mock.errors[0].message, "boom");
+      assertEquals(mock.events.some((e) => e.name === "exit_with_error"), true);
+      assertEquals(mock.isEnded(), true);
+    });
+
+    it("should capture non-Error throws (startSpan path)", () => {
+      const mock = createMockTracer();
+      assertThrows(() =>
+        withTraceSync(mock.tracer, "op", () => {
+          throw "string error";
+        })
+      );
+      assertEquals(mock.errors[0].message, "string error");
+    });
+
+    it("should use withActiveSpan when available", () => {
+      const mock = createMockTracerWithActiveSpan();
+      const result = withTraceSync(mock.tracer, "op", () => "active");
+      assertEquals(result, "active");
+      assertEquals(mock.events[0].name, "enter");
+      assertEquals(mock.events[1].name, "exit");
+      assertEquals(mock.isEnded(), true);
+    });
+
+    it("should capture errors via withActiveSpan path", () => {
+      const mock = createMockTracerWithActiveSpan();
+      assertThrows(
+        () =>
+          withTraceSync(mock.tracer, "op", () => {
+            throw new Error("active boom");
+          }),
+        Error,
+        "active boom",
+      );
+      assertEquals(mock.errors[0].message, "active boom");
+      assertEquals(mock.events.some((e) => e.name === "exit_with_error"), true);
+      assertEquals(mock.isEnded(), true);
+    });
+
+    it("should capture non-Error throws via withActiveSpan path", () => {
+      const mock = createMockTracerWithActiveSpan();
+      assertThrows(() =>
+        withTraceSync(mock.tracer, "op", () => {
+          throw "string error";
+        })
+      );
+      assertEquals(mock.errors[0].message, "string error");
+    });
+
+    it("should pass attributes to startSpan", () => {
+      let receivedAttrs: Record<string, string | number | boolean> | undefined;
+      const tracer: MoonlightTracer = {
+        startSpan(_name, attributes) {
+          receivedAttrs = attributes;
+          return { addEvent() {}, setError() {}, end() {} };
+        },
+      };
+      withTraceSync(tracer, "op", () => "ok", { key: "value" });
+      assertEquals(receivedAttrs, { key: "value" });
+    });
+  });
+});

--- a/src/transaction-builder/index.ts
+++ b/src/transaction-builder/index.ts
@@ -524,8 +524,8 @@ export class MoonlightTransactionBuilder {
     providerKeys: Signer | Keypair,
     signatureExpirationLedger: number,
     nonce?: string,
-  ) {
-    return withTrace(this._tracer, "MoonlightTransactionBuilder.signWithProvider", async (span) => {
+  ): Promise<void> {
+    return await withTrace(this._tracer, "MoonlightTransactionBuilder.signWithProvider", async (span) => {
       if (!nonce) nonce = generateNonce();
 
       span.addEvent("computing_auth_hash", { "expiration.ledger": signatureExpirationLedger });
@@ -556,8 +556,8 @@ export class MoonlightTransactionBuilder {
   public async signWithSpendUtxo(
     utxoKp: IUTXOKeypairBase,
     signatureExpirationLedger: number,
-  ) {
-    return withTrace(this._tracer, "MoonlightTransactionBuilder.signWithSpendUtxo", async (span) => {
+  ): Promise<void> {
+    return await withTrace(this._tracer, "MoonlightTransactionBuilder.signWithSpendUtxo", async (span) => {
       const spendOp = this.getSpendOperation(utxoKp.publicKey);
 
       assert(spendOp, new E.NO_SPEND_OPS(utxoKp.publicKey));
@@ -580,8 +580,8 @@ export class MoonlightTransactionBuilder {
     keys: Signer | Keypair,
     signatureExpirationLedger: number,
     nonce?: string,
-  ) {
-    return withTrace(this._tracer, "MoonlightTransactionBuilder.signExtWithEd25519", async (span) => {
+  ): Promise<void> {
+    return await withTrace(this._tracer, "MoonlightTransactionBuilder.signExtWithEd25519", async (span) => {
       const depositOp = this.getDepositOperation(
         keys.publicKey() as Ed25519PublicKey,
       );

--- a/src/transaction-builder/index.ts
+++ b/src/transaction-builder/index.ts
@@ -40,6 +40,7 @@ import * as E from "./error.ts";
 import { assert } from "../utils/assert/assert.ts";
 import { assertExtOpsExist } from "./validators/operations.ts";
 import type { PrivacyChannel } from "../privacy-channel/index.ts";
+import { type MoonlightTracer, withTrace, withTraceSync } from "../tracing/index.ts";
 
 export class MoonlightTransactionBuilder {
   private _create: CreateOperation[] = [];
@@ -58,22 +59,26 @@ export class MoonlightTransactionBuilder {
   > = new Map();
   private _extSignatures: Map<Ed25519PublicKey, xdr.SorobanAuthorizationEntry> =
     new Map();
+  private _tracer?: MoonlightTracer;
 
   constructor({
     channelId,
     authId,
     assetId,
     network,
+    tracer,
   }: {
     channelId: ContractId;
     authId: ContractId;
     assetId: ContractId;
     network: string;
+    tracer?: MoonlightTracer;
   }) {
     this._channelId = channelId;
     this._authId = authId;
     this._assetId = assetId;
     this._network = network;
+    this._tracer = tracer;
   }
 
   /**
@@ -89,6 +94,7 @@ export class MoonlightTransactionBuilder {
       authId: channelClient.getAuthId(),
       network: channelClient.getNetworkConfig().networkPassphrase,
       assetId: channelClient.getAssetId(),
+      tracer: channelClient.getTracer(),
     });
   }
 
@@ -314,12 +320,19 @@ export class MoonlightTransactionBuilder {
   //==========================================
 
   addOperation(op: MoonlightOperation): MoonlightTransactionBuilder {
-    if (op.isCreate()) return this.addCreate(op);
-    if (op.isSpend()) return this.addSpend(op);
-    if (op.isDeposit()) return this.addDeposit(op);
-    if (op.isWithdraw()) return this.addWithdraw(op);
+    return withTraceSync(this._tracer, "MoonlightTransactionBuilder.addOperation", (span) => {
+      let result: MoonlightTransactionBuilder;
+      if (op.isCreate()) result = this.addCreate(op);
+      else if (op.isSpend()) result = this.addSpend(op);
+      else if (op.isDeposit()) result = this.addDeposit(op);
+      else if (op.isWithdraw()) result = this.addWithdraw(op);
+      else throw new E.UNSUPPORTED_OP_TYPE((op as BaseOperation).getOperation());
 
-    throw new E.UNSUPPORTED_OP_TYPE((op as BaseOperation).getOperation());
+      span.addEvent("operation_added");
+      return result;
+    }, {
+      "operation.type": (op as BaseOperation).getOperation(),
+    });
   }
 
   private addCreate(op: CreateOperation): MoonlightTransactionBuilder {
@@ -512,41 +525,55 @@ export class MoonlightTransactionBuilder {
     signatureExpirationLedger: number,
     nonce?: string,
   ) {
-    if (!nonce) nonce = generateNonce();
+    return withTrace(this._tracer, "MoonlightTransactionBuilder.signWithProvider", async (span) => {
+      if (!nonce) nonce = generateNonce();
 
-    const authHash = await this.getOperationAuthEntryHash(
-      nonce,
-      signatureExpirationLedger,
-    );
+      span.addEvent("computing_auth_hash", { "expiration.ledger": signatureExpirationLedger });
 
-    const signedHash = isSigner(providerKeys)
-      // deno-lint-ignore no-explicit-any
-      ? providerKeys.sign(authHash as any)
-      : providerKeys.sign(authHash);
+      const authHash = await this.getOperationAuthEntryHash(
+        nonce,
+        signatureExpirationLedger,
+      );
 
-    this.addProviderInnerSignature(
-      providerKeys.publicKey() as Ed25519PublicKey,
-      signedHash as Buffer,
-      signatureExpirationLedger,
-      nonce,
-    );
+      span.addEvent("signing_hash");
+
+      const signedHash = isSigner(providerKeys)
+        // deno-lint-ignore no-explicit-any
+        ? providerKeys.sign(authHash as any)
+        : providerKeys.sign(authHash);
+
+      this.addProviderInnerSignature(
+        providerKeys.publicKey() as Ed25519PublicKey,
+        signedHash as Buffer,
+        signatureExpirationLedger,
+        nonce,
+      );
+
+      span.addEvent("provider_signature_added");
+    });
   }
 
   public async signWithSpendUtxo(
     utxoKp: IUTXOKeypairBase,
     signatureExpirationLedger: number,
   ) {
-    const spendOp = this.getSpendOperation(utxoKp.publicKey);
+    return withTrace(this._tracer, "MoonlightTransactionBuilder.signWithSpendUtxo", async (span) => {
+      const spendOp = this.getSpendOperation(utxoKp.publicKey);
 
-    assert(spendOp, new E.NO_SPEND_OPS(utxoKp.publicKey));
+      assert(spendOp, new E.NO_SPEND_OPS(utxoKp.publicKey));
 
-    await spendOp.signWithUTXO(
-      utxoKp,
-      this.getChannelId(),
-      signatureExpirationLedger,
-    );
+      span.addEvent("signing_utxo_spend", { "expiration.ledger": signatureExpirationLedger });
 
-    this.addInnerSignature(utxoKp.publicKey, spendOp.getUTXOSignature());
+      await spendOp.signWithUTXO(
+        utxoKp,
+        this.getChannelId(),
+        signatureExpirationLedger,
+      );
+
+      this.addInnerSignature(utxoKp.publicKey, spendOp.getUTXOSignature());
+
+      span.addEvent("utxo_spend_signed");
+    });
   }
 
   public async signExtWithEd25519(
@@ -554,28 +581,34 @@ export class MoonlightTransactionBuilder {
     signatureExpirationLedger: number,
     nonce?: string,
   ) {
-    const depositOp = this.getDepositOperation(
-      keys.publicKey() as Ed25519PublicKey,
-    );
+    return withTrace(this._tracer, "MoonlightTransactionBuilder.signExtWithEd25519", async (span) => {
+      const depositOp = this.getDepositOperation(
+        keys.publicKey() as Ed25519PublicKey,
+      );
 
-    assert(
-      depositOp,
-      new E.NO_DEPOSIT_OPS(keys.publicKey() as Ed25519PublicKey),
-    );
+      assert(
+        depositOp,
+        new E.NO_DEPOSIT_OPS(keys.publicKey() as Ed25519PublicKey),
+      );
 
-    await depositOp.signWithEd25519(
-      keys,
-      signatureExpirationLedger,
-      this.getChannelId(),
-      this.getAssetId(),
-      this.network,
-      nonce,
-    );
+      span.addEvent("signing_deposit_ed25519", { "expiration.ledger": signatureExpirationLedger });
 
-    this.addExtSignedEntry(
-      keys.publicKey() as Ed25519PublicKey,
-      depositOp.getEd25519Signature(),
-    );
+      await depositOp.signWithEd25519(
+        keys,
+        signatureExpirationLedger,
+        this.getChannelId(),
+        this.getAssetId(),
+        this.network,
+        nonce,
+      );
+
+      this.addExtSignedEntry(
+        keys.publicKey() as Ed25519PublicKey,
+        depositOp.getEd25519Signature(),
+      );
+
+      span.addEvent("ed25519_signature_added");
+    });
   }
 
   public getSignedAuthEntries(): xdr.SorobanAuthorizationEntry[] {

--- a/src/transaction-builder/index.unit.test.ts
+++ b/src/transaction-builder/index.unit.test.ts
@@ -19,6 +19,30 @@ import { UTXOKeypairBase } from "../core/utxo-keypair-base/index.ts";
 import type { UTXOPublicKey } from "../core/utxo-keypair-base/types.ts";
 import * as OPR_ERR from "../operation/error.ts";
 import * as TBU_ERR from "./error.ts";
+import type { MoonlightSpan, MoonlightTracer } from "../tracing/index.ts";
+
+function createSpyTracer() {
+  const events: { name: string; attributes?: Record<string, string | number | boolean> }[] = [];
+  let ended = false;
+
+  const span: MoonlightSpan = {
+    addEvent(name, attributes) {
+      events.push({ name, attributes });
+    },
+    setError() {},
+    end() {
+      ended = true;
+    },
+  };
+
+  const tracer: MoonlightTracer = {
+    startSpan(_name, _attributes) {
+      return span;
+    },
+  };
+
+  return { tracer, events, isEnded: () => ended };
+}
 
 describe("MoonlightTransactionBuilder", () => {
   let validPublicKey: Ed25519PublicKey;
@@ -591,6 +615,118 @@ describe("MoonlightTransactionBuilder", () => {
 
     describe("Signatures XDR", () => {
       // ... existing signatures XDR tests ...
+    });
+
+    describe("Tracing", () => {
+      it("should emit tracing events when adding operations with tracer", async () => {
+        const spy = createSpyTracer();
+        const utxo = (await generateP256KeyPair()).publicKey as UTXOPublicKey;
+        const operation = Operation.create(utxo, validAmount);
+
+        const testBuilder = new MoonlightTransactionBuilder({
+          channelId,
+          authId,
+          assetId,
+          network,
+          tracer: spy.tracer,
+        });
+
+        testBuilder.addOperation(operation);
+
+        const eventNames = spy.events.map((e) => e.name);
+        assertEquals(eventNames.includes("enter"), true);
+        assertEquals(eventNames.includes("operation_added"), true);
+        assertEquals(eventNames.includes("exit"), true);
+        assertEquals(spy.isEnded(), true);
+      });
+
+      it("should emit tracing events when signing with provider", async () => {
+        const spy = createSpyTracer();
+        const providerKeys = LocalSigner.generateRandom();
+
+        const testBuilder = new MoonlightTransactionBuilder({
+          channelId,
+          authId,
+          assetId,
+          network,
+          tracer: spy.tracer,
+        });
+
+        await testBuilder.signWithProvider(providerKeys, 1000000);
+
+        const eventNames = spy.events.map((e) => e.name);
+        assertEquals(eventNames.includes("enter"), true);
+        assertEquals(eventNames.includes("computing_auth_hash"), true);
+        assertEquals(eventNames.includes("signing_hash"), true);
+        assertEquals(eventNames.includes("provider_signature_added"), true);
+        assertEquals(eventNames.includes("exit"), true);
+        assertEquals(spy.isEnded(), true);
+      });
+
+      it("should emit tracing events when signing with spend UTXO", async () => {
+        const spy = createSpyTracer();
+        const utxoKeys = new UTXOKeypairBase(await generateP256KeyPair());
+        const utxo = utxoKeys.publicKey as UTXOPublicKey;
+        const spendOperation = Operation.spend(utxo);
+
+        spendOperation.addCondition(
+          Condition.create(
+            (await generateP256KeyPair()).publicKey as UTXOPublicKey,
+            1n,
+          ),
+        );
+
+        const testBuilder = new MoonlightTransactionBuilder({
+          channelId,
+          authId,
+          assetId,
+          network,
+          tracer: spy.tracer,
+        });
+
+        // deno-lint-ignore no-explicit-any
+        (testBuilder as any).addSpend(spendOperation);
+        spy.events.length = 0;
+
+        await testBuilder.signWithSpendUtxo(utxoKeys, 1000000);
+
+        const eventNames = spy.events.map((e) => e.name);
+        assertEquals(eventNames.includes("enter"), true);
+        assertEquals(eventNames.includes("signing_utxo_spend"), true);
+        assertEquals(eventNames.includes("utxo_spend_signed"), true);
+        assertEquals(eventNames.includes("exit"), true);
+        assertEquals(spy.isEnded(), true);
+      });
+
+      it("should emit tracing events when signing ext with Ed25519", async () => {
+        const spy = createSpyTracer();
+        const userKeys = LocalSigner.generateRandom();
+        const pubKey = userKeys.publicKey() as Ed25519PublicKey;
+        const condition = Condition.deposit(pubKey, validAmount);
+        const operation = Operation.deposit(pubKey, validAmount);
+        operation.addCondition(condition);
+
+        const testBuilder = new MoonlightTransactionBuilder({
+          channelId,
+          authId,
+          assetId,
+          network,
+          tracer: spy.tracer,
+        });
+
+        // deno-lint-ignore no-explicit-any
+        (testBuilder as any).addDeposit(operation);
+        spy.events.length = 0;
+
+        await testBuilder.signExtWithEd25519(userKeys, 1000000, generateNonce());
+
+        const eventNames = spy.events.map((e) => e.name);
+        assertEquals(eventNames.includes("enter"), true);
+        assertEquals(eventNames.includes("signing_deposit_ed25519"), true);
+        assertEquals(eventNames.includes("ed25519_signature_added"), true);
+        assertEquals(eventNames.includes("exit"), true);
+        assertEquals(spy.isEnded(), true);
+      });
     });
   });
 

--- a/src/utxo-based-account/index.ts
+++ b/src/utxo-based-account/index.ts
@@ -8,6 +8,7 @@ import type {
 } from "./types.ts";
 import * as E from "./error.ts";
 import { assert } from "../utils/assert/assert.ts";
+import { type MoonlightTracer, withTrace, withTraceSync } from "../tracing/index.ts";
 /**
  * Manages UTXO-based accounts with advanced features for privacy-focused blockchain operations
  */
@@ -21,6 +22,7 @@ export class UtxoBasedAccount<
   private batchSize: number;
   private fetchBalances?: (publicKeys: Uint8Array[]) => Promise<bigint[]>;
   private readonly maxReservationAgeMs: number;
+  private tracer?: MoonlightTracer;
 
   // Primary storage: index -> UTXO
   private utxos: Map<number, UTXOKeypair<Context, Index>> = new Map();
@@ -57,6 +59,7 @@ export class UtxoBasedAccount<
     this.fetchBalances = args.options?.fetchBalances;
     this.nextIndex = args.options?.startIndex ?? 1;
     this.maxReservationAgeMs = args.options?.maxReservationAgeMs ?? 300000; // Default 5 minutes
+    this.tracer = args.options?.tracer;
   }
 
   private createProxy(
@@ -98,33 +101,36 @@ export class UtxoBasedAccount<
     startIndex?: number;
     count?: number;
   }): Promise<number[]> {
-    assert(startIndex >= 0, new E.NEGATIVE_INDEX(startIndex));
-    assert(count > 0, new E.UTXO_TO_DERIVE_TOO_LOW(count));
+    return withTrace(this.tracer, "UtxoBasedAccount.deriveBatch", async (span) => {
+      assert(startIndex >= 0, new E.NEGATIVE_INDEX(startIndex));
+      assert(count > 0, new E.UTXO_TO_DERIVE_TOO_LOW(count));
 
-    const derivedIndices: number[] = [];
+      span.addEvent("deriving_utxos", {
+        "derive.startIndex": startIndex,
+        "derive.count": count,
+      });
 
-    for (let i = 0; i < count; i++) {
-      const utxoIndex = startIndex + i;
-      const keypair = await UTXOKeypair.fromDerivator(
-        this.derivator,
-        `${utxoIndex}` as Index,
-      );
+      const derivedIndices: number[] = [];
 
-      // Create proxied UTXO that automatically updates status index
-      const proxiedKeypair = this.createProxy(keypair);
+      for (let i = 0; i < count; i++) {
+        const utxoIndex = startIndex + i;
+        const keypair = await UTXOKeypair.fromDerivator(
+          this.derivator,
+          `${utxoIndex}` as Index,
+        );
 
-      // Store in primary map
-      this.utxos.set(utxoIndex, proxiedKeypair);
+        const proxiedKeypair = this.createProxy(keypair);
+        this.utxos.set(utxoIndex, proxiedKeypair);
+        proxiedKeypair.balance = -1n;
+        proxiedKeypair.status = UTXOStatus.FREE;
+        derivedIndices.push(utxoIndex);
+      }
 
-      // Initialize status and balance for new UTXOs
-      proxiedKeypair.balance = -1n; // Mark as not created yet
-      proxiedKeypair.status = UTXOStatus.FREE;
+      this.nextIndex = Math.max(this.nextIndex, startIndex + count);
 
-      derivedIndices.push(utxoIndex);
-    }
-
-    this.nextIndex = Math.max(this.nextIndex, startIndex + count);
-    return derivedIndices;
+      span.addEvent("derivation_complete", { "derived.count": derivedIndices.length });
+      return derivedIndices;
+    });
   }
 
   /**
@@ -134,45 +140,42 @@ export class UtxoBasedAccount<
    * @param indices Optional array of specific indices to load
    */
   async batchLoad(states?: UTXOStatus[], indices?: number[]): Promise<void> {
-    assert(this.fetchBalances, new E.MISSING_BATCH_FETCH_FN());
+    return withTrace(this.tracer, "UtxoBasedAccount.batchLoad", async (span) => {
+      assert(this.fetchBalances, new E.MISSING_BATCH_FETCH_FN());
 
-    // Get all relevant UTXOs
-    const utxosToCheck = Array.from(this.utxos.entries()).filter(
-      ([index, utxo]) =>
-        (!states || states.includes(utxo.status)) &&
-        (!indices || indices.includes(index)),
-    );
+      const utxosToCheck = Array.from(this.utxos.entries()).filter(
+        ([index, utxo]) =>
+          (!states || states.includes(utxo.status)) &&
+          (!indices || indices.includes(index)),
+      );
 
-    // Process UTXOs in batches
-    for (let i = 0; i < utxosToCheck.length; i += this.batchSize) {
-      const batchEntries = utxosToCheck.slice(i, i + this.batchSize);
-      const publicKeys = batchEntries.map(([, utxo]) => utxo.publicKey);
-      const balances = await this.fetchBalances(publicKeys);
+      span.addEvent("loading_balances", { "utxos.count": utxosToCheck.length });
 
-      batchEntries.forEach(([index, utxo], idx) => {
-        const balance = balances[idx];
+      for (let i = 0; i < utxosToCheck.length; i += this.batchSize) {
+        const batchEntries = utxosToCheck.slice(i, i + this.batchSize);
+        const publicKeys = batchEntries.map(([, utxo]) => utxo.publicKey);
+        const balances = await this.fetchBalances(publicKeys);
 
-        // Update UTXO balance and state based on balance
-        utxo.balance = balance;
+        batchEntries.forEach(([index, utxo], idx) => {
+          const balance = balances[idx];
+          utxo.balance = balance;
 
-        // Update status based on balance:
-        // - balance > 0: UNSPENT (has funds)
-        // - balance = 0: SPENT (exists on chain but empty)
-        // - balance = -1: FREE (not created yet)
-        if (balance > 0n) {
-          utxo.status = UTXOStatus.UNSPENT;
-        } else if (balance === 0n) {
-          utxo.status = UTXOStatus.SPENT;
-        } else {
-          utxo.status = UTXOStatus.FREE;
-        }
+          if (balance > 0n) {
+            utxo.status = UTXOStatus.UNSPENT;
+          } else if (balance === 0n) {
+            utxo.status = UTXOStatus.SPENT;
+          } else {
+            utxo.status = UTXOStatus.FREE;
+          }
 
-        // If this UTXO was reserved and now has balance, unreserve it
-        if (balance > 0n && this.isReserved(index)) {
-          this.unreserve(index);
-        }
-      });
-    }
+          if (balance > 0n && this.isReserved(index)) {
+            this.unreserve(index);
+          }
+        });
+      }
+
+      span.addEvent("balances_loaded");
+    });
   }
 
   /**
@@ -235,41 +238,58 @@ export class UtxoBasedAccount<
     amount: bigint,
     strategy: UTXOSelectionStrategy = UTXOSelectionStrategy.SEQUENTIAL,
   ): UTXOSelectionResult<Context> | null {
-    const unspentUtxos = this.getUTXOsByState(UTXOStatus.UNSPENT);
+    return withTraceSync(this.tracer, "UtxoBasedAccount.selectUTXOsForTransfer", (span) => {
+      const unspentUtxos = this.getUTXOsByState(UTXOStatus.UNSPENT);
 
-    if (strategy === UTXOSelectionStrategy.RANDOM) {
-      // Fisher-Yates shuffle for random selection
-      for (let i = unspentUtxos.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [unspentUtxos[i], unspentUtxos[j]] = [unspentUtxos[j], unspentUtxos[i]];
+      span.addEvent("unspent_utxos_found", { "utxos.count": unspentUtxos.length });
+
+      if (strategy === UTXOSelectionStrategy.RANDOM) {
+        // Fisher-Yates shuffle for random selection
+        for (let i = unspentUtxos.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [unspentUtxos[i], unspentUtxos[j]] = [unspentUtxos[j], unspentUtxos[i]];
+        }
       }
-    }
 
-    let totalAmount = 0n;
-    const selectedUTXOs: UTXOKeypair<Context, Index>[] = [];
+      let totalAmount = 0n;
+      const selectedUTXOs: UTXOKeypair<Context, Index>[] = [];
 
-    for (const utxo of unspentUtxos) {
-      selectedUTXOs.push(utxo);
-      totalAmount += utxo.balance;
+      for (const utxo of unspentUtxos) {
+        selectedUTXOs.push(utxo);
+        totalAmount += utxo.balance;
 
-      if (totalAmount >= amount) {
-        break;
+        if (totalAmount >= amount) {
+          break;
+        }
       }
-    }
 
-    // If we couldn't accumulate enough funds, return null
-    if (totalAmount < amount) {
-      return null;
-    }
+      // If we couldn't accumulate enough funds, return null
+      if (totalAmount < amount) {
+        span.addEvent("insufficient_funds", {
+          "total.available": totalAmount.toString(),
+          "amount.requested": amount.toString(),
+        });
+        return null;
+      }
 
-    // Calculate change amount
-    const changeAmount = totalAmount - amount;
+      // Calculate change amount
+      const changeAmount = totalAmount - amount;
 
-    return {
-      selectedUTXOs,
-      totalAmount,
-      changeAmount,
-    };
+      span.addEvent("selection_complete", {
+        "selected.count": selectedUTXOs.length,
+        "total.amount": totalAmount.toString(),
+        "change.amount": changeAmount.toString(),
+      });
+
+      return {
+        selectedUTXOs,
+        totalAmount,
+        changeAmount,
+      };
+    }, {
+      "select.amount": amount.toString(),
+      "select.strategy": strategy,
+    });
   }
 
   /**

--- a/src/utxo-based-account/index.ts
+++ b/src/utxo-based-account/index.ts
@@ -101,7 +101,7 @@ export class UtxoBasedAccount<
     startIndex?: number;
     count?: number;
   }): Promise<number[]> {
-    return withTrace(this.tracer, "UtxoBasedAccount.deriveBatch", async (span) => {
+    return await withTrace(this.tracer, "UtxoBasedAccount.deriveBatch", async (span) => {
       assert(startIndex >= 0, new E.NEGATIVE_INDEX(startIndex));
       assert(count > 0, new E.UTXO_TO_DERIVE_TOO_LOW(count));
 
@@ -140,7 +140,7 @@ export class UtxoBasedAccount<
    * @param indices Optional array of specific indices to load
    */
   async batchLoad(states?: UTXOStatus[], indices?: number[]): Promise<void> {
-    return withTrace(this.tracer, "UtxoBasedAccount.batchLoad", async (span) => {
+    return await withTrace(this.tracer, "UtxoBasedAccount.batchLoad", async (span) => {
       assert(this.fetchBalances, new E.MISSING_BATCH_FETCH_FN());
 
       const utxosToCheck = Array.from(this.utxos.entries()).filter(

--- a/src/utxo-based-account/index.unit.test.ts
+++ b/src/utxo-based-account/index.unit.test.ts
@@ -13,6 +13,30 @@ import { UTXOStatus } from "../core/utxo-keypair/types.ts";
 import { StellarDerivator } from "../derivation/stellar/index.ts";
 import { StellarNetworkId } from "../derivation/stellar/stellar-network-id.ts";
 import * as UBA_ERR from "./error.ts";
+import type { MoonlightSpan, MoonlightTracer } from "../tracing/index.ts";
+
+function createSpyTracer() {
+  const events: { name: string; attributes?: Record<string, string | number | boolean> }[] = [];
+  let ended = false;
+
+  const span: MoonlightSpan = {
+    addEvent(name, attributes) {
+      events.push({ name, attributes });
+    },
+    setError() {},
+    end() {
+      ended = true;
+    },
+  };
+
+  const tracer: MoonlightTracer = {
+    startSpan(_name, _attributes) {
+      return span;
+    },
+  };
+
+  return { tracer, events, isEnded: () => ended };
+}
 
 // Test secret key and contract ID for Stellar Testnet
 const TEST_SECRET_KEY =
@@ -277,6 +301,122 @@ Deno.test("UtxoBasedAccount", async (t) => {
       // Change one UTXO to SPENT state
       account.updateUTXOState(2, UTXOStatus.SPENT, 0n);
       assertEquals(account.getTotalBalance(), 400n);
+    },
+  );
+
+  await t.step(
+    "deriveBatch should emit tracing events when tracer is provided",
+    async () => {
+      const root = TEST_SECRET_KEY;
+      const derivator = getBaseDerivator();
+      const spy = createSpyTracer();
+
+      const account = new UtxoBasedAccount({
+        derivator,
+        root,
+        options: { tracer: spy.tracer },
+      });
+
+      await account.deriveBatch({ count: 2 });
+
+      const eventNames = spy.events.map((e) => e.name);
+      assertEquals(eventNames.includes("enter"), true);
+      assertEquals(eventNames.includes("deriving_utxos"), true);
+      assertEquals(eventNames.includes("derivation_complete"), true);
+      assertEquals(eventNames.includes("exit"), true);
+      assertEquals(spy.isEnded(), true);
+    },
+  );
+
+  await t.step(
+    "batchLoad should emit tracing events when tracer is provided",
+    async () => {
+      const root = TEST_SECRET_KEY;
+      const derivator = getBaseDerivator();
+      const spy = createSpyTracer();
+
+      const account = new UtxoBasedAccount({
+        derivator,
+        root,
+        options: {
+          tracer: spy.tracer,
+          fetchBalances: async () => [10n, 0n],
+        },
+      });
+
+      await account.deriveBatch({ count: 2 });
+      // Reset spy events after deriveBatch
+      spy.events.length = 0;
+
+      await account.batchLoad();
+
+      const eventNames = spy.events.map((e) => e.name);
+      assertEquals(eventNames.includes("enter"), true);
+      assertEquals(eventNames.includes("loading_balances"), true);
+      assertEquals(eventNames.includes("balances_loaded"), true);
+      assertEquals(eventNames.includes("exit"), true);
+      assertEquals(spy.isEnded(), true);
+    },
+  );
+
+  await t.step(
+    "selectUTXOsForTransfer should emit tracing events when tracer is provided",
+    async () => {
+      const root = TEST_SECRET_KEY;
+      const derivator = getBaseDerivator();
+      const spy = createSpyTracer();
+
+      const account = new UtxoBasedAccount({
+        derivator,
+        root,
+        options: {
+          tracer: spy.tracer,
+          fetchBalances: async () => [100n, 200n],
+        },
+      });
+
+      await account.deriveBatch({ count: 2 });
+      await account.batchLoad();
+      spy.events.length = 0;
+
+      const result = account.selectUTXOsForTransfer(150n);
+
+      assertExists(result);
+      const eventNames = spy.events.map((e) => e.name);
+      assertEquals(eventNames.includes("enter"), true);
+      assertEquals(eventNames.includes("unspent_utxos_found"), true);
+      assertEquals(eventNames.includes("selection_complete"), true);
+      assertEquals(eventNames.includes("exit"), true);
+      assertEquals(spy.isEnded(), true);
+    },
+  );
+
+  await t.step(
+    "selectUTXOsForTransfer should emit insufficient_funds event when tracer is provided",
+    async () => {
+      const root = TEST_SECRET_KEY;
+      const derivator = getBaseDerivator();
+      const spy = createSpyTracer();
+
+      const account = new UtxoBasedAccount({
+        derivator,
+        root,
+        options: {
+          tracer: spy.tracer,
+          fetchBalances: async () => [100n, 200n],
+        },
+      });
+
+      await account.deriveBatch({ count: 2 });
+      await account.batchLoad();
+      spy.events.length = 0;
+
+      const result = account.selectUTXOsForTransfer(1000n);
+
+      assertEquals(result, null);
+      const eventNames = spy.events.map((e) => e.name);
+      assertEquals(eventNames.includes("insufficient_funds"), true);
+      assertEquals(spy.isEnded(), true);
     },
   );
 });

--- a/src/utxo-based-account/types.ts
+++ b/src/utxo-based-account/types.ts
@@ -1,5 +1,6 @@
 import type { UTXOKeypair } from "../core/utxo-keypair/index.ts";
 import type { BaseDerivator } from "../derivation/base/index.ts";
+import type { MoonlightTracer } from "../tracing/index.ts";
 
 /**
  * Result of UTXO selection for transfers
@@ -22,5 +23,6 @@ export type UTXOBasedAccountConstructorArgs<
     fetchBalances?: (publicKeys: Uint8Array[]) => Promise<bigint[]>;
     startIndex?: number;
     maxReservationAgeMs?: number;
+    tracer?: MoonlightTracer;
   };
 };

--- a/src/utxo-based-account/utxo-based-stellar-account/index.ts
+++ b/src/utxo-based-account/utxo-based-stellar-account/index.ts
@@ -25,11 +25,11 @@ export class UtxoBasedStellarAccount extends UtxoBasedAccount<
     channelClient: PrivacyChannel;
     root: StellarDerivationRoot;
     options?: Omit<
-      UTXOBasedAccountConstructorArgs<
+      NonNullable<UTXOBasedAccountConstructorArgs<
         StellarDerivationContext,
         StellarDerivationRoot,
         StellarDerivationIndex
-      >["options"],
+      >["options"]>,
       "fetchBalances"
     >;
   }): UtxoBasedStellarAccount {
@@ -40,6 +40,7 @@ export class UtxoBasedStellarAccount extends UtxoBasedAccount<
       options: {
         ...(args.options ?? {}),
         fetchBalances: channelClient.getBalancesFetcher(),
+        tracer: args.options?.tracer ?? channelClient.getTracer(),
       },
     });
   }


### PR DESCRIPTION
## Summary

- Adds framework-agnostic tracing interfaces (`MoonlightTracer`, `MoonlightSpan`, `NOOP_TRACER`) with zero runtime dependency on `@opentelemetry/api`
- `withTrace` (async) and `withTraceSync` (sync) helpers with guaranteed span lifecycle, error recording, and `exit_with_error` events
- Optional `withActiveSpan` method enables W3C `traceparent` propagation for distributed tracing — consumers bridge to their own OTel backend
- Instruments `PrivacyChannel` (read/invoke/invokeRaw), `UtxoBasedAccount` (deriveBatch/batchLoad/selectUTXOsForTransfer), and `MoonlightTransactionBuilder` (addOperation/sign methods)
- Tracing is fully opt-in: pass a tracer to constructors, or leave it undefined for zero overhead (`NOOP_TRACER`)

## How to verify

Run the full E2E flow with Jaeger locally — see the [step-by-step Jaeger guide](https://github.com/Moonlight-Protocol/local-dev/blob/feat/otel-instrumentation/e2e/README.md#opentelemetry--jaeger) in `local-dev`.

> **Note:** To test locally before this SDK version is published, revert the last commit in the `local-dev` PR (`chore: switch SDK import from local path to JSR`) so that the E2E test imports the SDK from the local path.

## Test plan

- [ ] `deno task test` passes (no breaking changes — tracing is optional)
- [ ] E2E with `deno task e2e` + `deno task verify-otel` passes 16/16 checks
- [ ] Jaeger shows PrivacyChannel, UtxoBasedAccount, and MoonlightTransactionBuilder spans