### PR TITLE
fix: bump @colibri/core to ^0.20.2 (txBadSeq fix)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonlight/moonlight-sdk",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "A privacy-focused toolkit for the Moonlight protocol on Stellar Soroban smart contracts.",
   "license": "MIT",
   "tasks": {
@@ -14,7 +14,7 @@
   "exports": "./mod.ts",
   "imports": {
     "@fifo/convee": "jsr:@fifo/convee@^0.5.0",
-    "@colibri/core": "jsr:@colibri/core@^0.16.1",
+    "@colibri/core": "jsr:@colibri/core@^0.20.2",
     "@noble/curves": "jsr:@noble/curves@^1.8.0",
     "@noble/curves/p256": "jsr:@noble/curves@^1.8.0/p256",
     "@noble/curves/abstract/modular": "jsr:@noble/curves@^1.8.0/abstract/modular",
@@ -22,7 +22,7 @@
     "@noble/hashes/sha256": "jsr:@noble/hashes@^1.6.1/sha256",
     "@noble/hashes/hkdf": "jsr:@noble/hashes@^1.6.1/hkdf",
     "@noble/secp256k1": "jsr:@noble/secp256k1",
-    "@stellar/stellar-sdk": "npm:@stellar/stellar-sdk@^14.2.0",
+    "@stellar/stellar-sdk": "npm:@stellar/stellar-sdk@^15.0.1",
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "@std/testing": "jsr:@std/testing@^1.0.0",
     "tslib": "npm:tslib@2.5.0",

--- a/src/operation/index.ts
+++ b/src/operation/index.ts
@@ -558,11 +558,14 @@ export class MoonlightOperation implements BaseOperation {
     let signedAuthEntry: xdr.SorobanAuthorizationEntry;
 
     if (isSigner(depositorKeys)) {
-      signedAuthEntry = await depositorKeys.signSorobanAuthEntry(
+      // Colibri Signer.signSorobanAuthEntry returns SorobanAuthorizationEntryLike
+      // (a duck-typed superset), but the underlying value is a concrete
+      // xdr.SorobanAuthorizationEntry from stellar-sdk.
+      signedAuthEntry = (await depositorKeys.signSorobanAuthEntry(
         rawAuthEntry,
         signatureExpirationLedger,
         networkPassphrase,
-      );
+      )) as xdr.SorobanAuthorizationEntry;
     } else {
       signedAuthEntry = await authorizeEntry(
         rawAuthEntry,

--- a/test/integration/privacy-channel.integration.test.ts
+++ b/test/integration/privacy-channel.integration.test.ts
@@ -7,7 +7,7 @@ import {
   LocalSigner,
   NativeAccount,
   NetworkConfig,
-  P_SimulateTransactionErrors,
+  SimulateTransactionErrors,
 } from "@colibri/core";
 
 import type {
@@ -276,7 +276,7 @@ describe(
             config: txConfig,
           })
           .catch((e) => {
-            if (e instanceof P_SimulateTransactionErrors.SIMULATION_FAILED) {
+            if (e instanceof SimulateTransactionErrors.SIMULATION_FAILED) {
               console.error("Error invoking contract:", e);
               console.error(
                 "Transaction XDR:",

--- a/test/integration/utxo-based-account.integration.test.ts
+++ b/test/integration/utxo-based-account.integration.test.ts
@@ -11,7 +11,7 @@ import {
   LocalSigner,
   NativeAccount,
   NetworkConfig,
-  P_SimulateTransactionErrors,
+  SimulateTransactionErrors,
   type TransactionConfig,
 } from "@colibri/core";
 
@@ -311,7 +311,7 @@ describe(
             config: txConfig,
           })
           .catch((e) => {
-            if (e instanceof P_SimulateTransactionErrors.SIMULATION_FAILED) {
+            if (e instanceof SimulateTransactionErrors.SIMULATION_FAILED) {
               console.error("Error invoking contract:", e);
               console.error(
                 "Transaction XDR:",
@@ -589,7 +589,7 @@ describe(
             config: txConfig,
           })
           .catch((e) => {
-            if (e instanceof P_SimulateTransactionErrors.SIMULATION_FAILED) {
+            if (e instanceof SimulateTransactionErrors.SIMULATION_FAILED) {
               console.error("Error invoking withdraw contract:", e);
               console.error(
                 "Transaction XDR:",


### PR DESCRIPTION
## Summary

Bumps `@colibri/core` to `^0.20.2` to pick up the fix for the `AssembleTransaction` sequence-number precision bug ([colibri#97](https://github.com/fazzatti/colibri/pull/97)). Without this bump, every flow that goes through `PrivacyChannel` / Colibri pipelines on testnet or mainnet hits `txBadSeq` intermittently because sequence numbers exceed `Number.MAX_SAFE_INTEGER` (2^53).

Concrete failure observed on testnet (provider-platform):

- Build output seq: `9_771_475_800_162_306`
- After AssembleTransaction's `Number(seq) - 1` round-trip: `9_771_475_800_162_305`
- That's the seq the prior tx already consumed → Soroban returns `txBadSeq`

## Changes

- `deno.json` — `@colibri/core` `^0.16.1` → `^0.20.2`, `@stellar/stellar-sdk` `^14.2.0` → `^15.0.1` to match colibri's pin and avoid two stellar-sdk versions coexisting (which would duplicate `Spec` types and break `Contract` config typing). Bumps `version` to `0.8.0` since the stellar-sdk peer requirement changed.
- `src/operation/index.ts` — colibri 0.20.x narrows `Signer.signSorobanAuthEntry` return to `SorobanAuthorizationEntryLike` (a duck-typed superset). Cast back to `xdr.SorobanAuthorizationEntry` at the one consumer site; the runtime value is still a concrete stellar-sdk entry.

## Test plan

- [x] `deno lint` — clean
- [x] `deno check mod.ts` — clean
- [x] `deno task test:unit` — `15 passed (188 steps), 0 failed`
- [ ] CI integration tests