### PR TITLE
feat(errors): map contract error codes 3006/3007/3008

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonlight/moonlight-sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A privacy-focused toolkit for the Moonlight protocol on Stellar Soroban smart contracts.",
   "license": "MIT",
   "tasks": {

--- a/src/error/contract-errors.ts
+++ b/src/error/contract-errors.ts
@@ -145,6 +145,19 @@ export const MoonlightContractError: KnownContractErrorMap = {
     details:
       "An amount calculation went below the minimum supported integer value.",
   },
+  3006: {
+    message: "UnauthorizedOperation",
+    details:
+      "An executed create/withdraw effect is not covered by an owner-signed condition, or an owner-signed create/withdraw condition is not executed by the bundle.",
+  },
+  3007: {
+    message: "InvalidExternalAmount",
+    details: "A deposit or withdraw amount was not strictly positive.",
+  },
+  3008: {
+    message: "ReentrantCall",
+    details: "transact was re-entered while a call was already in progress.",
+  },
   4000: {
     message: "NotEd25519AccountAddress",
     details:


### PR DESCRIPTION
## What

Adds the three contract error codes introduced by the audit remediation (soroban-core #32) to the SDK's `MoonlightContractError` map so the map mirrors the deployed contract enum exactly:

- **3006 `UnauthorizedOperation`** (MOON-01) — an executed create/withdraw effect is not covered by an owner-signed condition, or an owner-signed create/withdraw condition is not executed by the bundle.
- **3007 `InvalidExternalAmount`** (MOON-05) — a deposit or withdraw amount was not strictly positive.
- **3008 `ReentrantCall`** (MOON-06) — `transact` was re-entered while a call was already in progress.

`message` = the enum variant name; `details` = the contract's own doc-comment wording (`modules/errors/src/lib.rs`), rendered as plain prose to match the existing 1xxx–4xxx entries.

## Why

Before this, when the audit-remediated contract rejects a malformed/attack bundle with 3006/3007/3008, consumers surface a raw "unknown error 300x" instead of a readable message. These codes only ever fire on malformed/attack bundles, never on a normal payment — so this is backward-compatible and does not change runtime behavior for legit traffic.

## Scope

Error map + version only. **No** bundle-format, transaction-builder, conditions, or signing changes. The SDK map now has no remaining gap vs the contract enum (1000–1013, 2000–2009, 3000–3008, 4000–4001).

Version: 0.9.0 → 0.9.1.

## Verification

- `deno fmt --check` — clean (103 files)
- `deno lint` — clean (94 files)
- `deno task test` (full suite incl. integration) — green; `src/error/contract-errors.ts` at 100% coverage

## Related

- soroban-core #32 (audit remediation, merged) — source of the canonical codes/wording.
- Consumer SDK-pin bumps to `^0.9.1` follow in separate per-repo PRs once this is merged + published.