### PR TITLE
fix(error): add submit-time decodeContractError for on-chain error surfacing

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonlight/moonlight-sdk",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A privacy-focused toolkit for the Moonlight protocol on Stellar Soroban smart contracts.",
   "license": "MIT",
   "tasks": {

--- a/mod.ts
+++ b/mod.ts
@@ -31,6 +31,7 @@ export * from "./src/utils/index.ts";
 
 export * from "./src/error/index.ts";
 export * from "./src/error/contract-errors.ts";
+export * from "./src/error/decode-contract-error.ts";
 export type * from "./src/error/types.ts";
 export * from "./src/error/errors.ts";
 

--- a/src/error/decode-contract-error.ts
+++ b/src/error/decode-contract-error.ts
@@ -1,0 +1,99 @@
+import { MoonlightContractError } from "./contract-errors.ts";
+
+/**
+ * A soroban contract error decoded back to its catalog identity.
+ *
+ * `code` is the numeric code from `soroban-core/modules/errors/src/lib.rs`
+ * (AUTH 1000–1099, UTXO 2000–2099, CHANNEL 3000–3099, HELPER 4000–4099);
+ * `name`/`details` come from {@link MoonlightContractError}.
+ */
+export interface DecodedContractError {
+  /** Numeric soroban error code, e.g. `1010`. */
+  code: number;
+  /** Catalog variant name, e.g. `"SignatureExpired"`. */
+  name: string;
+  /** Catalog human description of the variant. */
+  details: string;
+  /** Origin layer — always on-chain for a decoded contract error. */
+  source: "onchain";
+}
+
+/** Duck-typed shape of Colibri's contract-error-matcher payload. */
+interface MatchCarrier {
+  meta?: { data?: { match?: { code?: unknown } } };
+  message?: unknown;
+  cause?: unknown;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+/** Reverse index: catalog variant name (e.g. "SignatureExpired") → code. */
+const CODE_BY_NAME: Record<string, number> = Object.fromEntries(
+  Object.entries(MoonlightContractError).map((
+    [code, entry],
+  ) => [entry.message, Number(code)]),
+);
+
+/**
+ * Colibri renders a matched contract error as `Contract error: <Variant>`.
+ * Recovering the code from that message is the fallback when the structured
+ * `meta.data.match` payload is not present on the (possibly re-wrapped) error.
+ */
+function codeFromMessage(message: unknown): number | null {
+  if (typeof message !== "string") return null;
+  const m = message.match(/Contract error:\s*([A-Za-z0-9]+)/);
+  if (!m) return null;
+  const code = CODE_BY_NAME[m[1]];
+  return typeof code === "number" ? code : null;
+}
+
+function decoded(code: number): DecodedContractError | null {
+  const entry = MoonlightContractError[code];
+  if (!entry) return null;
+  return {
+    code,
+    name: entry.message,
+    details: entry.details ?? "",
+    source: "onchain",
+  };
+}
+
+/**
+ * Decode a caught error into its soroban contract identity, if it carries one.
+ *
+ * Colibri's `createContractErrorMatcherPlugin` (wired by
+ * {@link createMoonlightContractErrorPlugins}) runs on both the simulate and
+ * submit pipelines and attaches the decoded variant at
+ * `error.meta.data.match.code`. Provider-side wrappers copy the envelope onto
+ * their own error (`Object.assign(this, originalError)`) and may nest the
+ * original under `cause`, so this walks the cause chain to find the match.
+ *
+ * This is the single submit-time decoder for the whole chain: it turns an
+ * opaque thrown error into the stable numeric code that the API boundary
+ * translates into a `StructuredError`. Returns `null` when the error is not a
+ * contract revert (e.g. a network/RPC failure), so callers can distinguish
+ * deterministic on-chain reverts from transient failures.
+ */
+export function decodeContractError(err: unknown): DecodedContractError | null {
+  let current: unknown = err;
+  // Bounded walk of the cause chain; wrapping is shallow in practice.
+  for (let depth = 0; depth < 8 && isRecord(current); depth++) {
+    const carrier = current as MatchCarrier;
+    // Primary: the structured match payload from the matcher plugin.
+    const code = carrier.meta?.data?.match?.code;
+    if (typeof code === "number") {
+      // An unmapped code means catalog drift — surface null rather than a
+      // misleading half-decode.
+      return decoded(code);
+    }
+    // Fallback: recover the code from the rendered "Contract error: <Variant>"
+    // message (survives re-wrapping that copies only the message).
+    const fromMsg = codeFromMessage(carrier.message);
+    if (fromMsg !== null) return decoded(fromMsg);
+
+    current = carrier.cause;
+  }
+  return null;
+}

--- a/src/error/decode-contract-error.unit.test.ts
+++ b/src/error/decode-contract-error.unit.test.ts
@@ -1,0 +1,51 @@
+import { assertEquals } from "@std/assert";
+import { decodeContractError } from "./decode-contract-error.ts";
+import { MoonlightContractError } from "./contract-errors.ts";
+
+/** Mimics Colibri's contract-error-matcher thrown-error envelope. */
+function matcherError(code: number): unknown {
+  return Object.assign(new Error(`Contract error: code ${code}`), {
+    meta: { data: { match: { code } } },
+  });
+}
+
+Deno.test("decodeContractError", async (t) => {
+  await t.step("decodes a direct matcher error to its catalog identity", () => {
+    const decoded = decodeContractError(matcherError(1010));
+    assertEquals(decoded, {
+      code: 1010,
+      name: MoonlightContractError[1010].message,
+      details: MoonlightContractError[1010].details,
+      source: "onchain",
+    });
+  });
+
+  await t.step("walks the cause chain when the match is wrapped", () => {
+    const wrapped = new Error("Slot execution failed", {
+      cause: new Error("submit failed", { cause: matcherError(2002) }),
+    });
+    assertEquals(decodeContractError(wrapped)?.code, 2002);
+    assertEquals(decodeContractError(wrapped)?.name, "UtxoAlreadySpent");
+  });
+
+  await t.step("recovers the code from the rendered message", () => {
+    // No structured match payload — only the "Contract error: <Variant>" text,
+    // as when a wrapper copies just the message.
+    const wrapped = new Error("Contract error: SignatureExpired", {
+      cause: new Error("submit failed"),
+    });
+    const d = decodeContractError(wrapped);
+    assertEquals(d?.code, 1010);
+    assertEquals(d?.name, "SignatureExpired");
+  });
+
+  await t.step("returns null for a non-contract (network) error", () => {
+    assertEquals(decodeContractError(new Error("RPC timeout")), null);
+    assertEquals(decodeContractError(undefined), null);
+    assertEquals(decodeContractError({ meta: { data: {} } }), null);
+  });
+
+  await t.step("returns null for an unmapped code (catalog drift)", () => {
+    assertEquals(decodeContractError(matcherError(9999)), null);
+  });
+});


### PR DESCRIPTION
Part of the mid-flight error-bubbling fix (ClickUp 86c8t0zux, half 2). **Anchor PR** — the four consumer PRs pin the version this publishes.

## What
Adds `decodeContractError(err)` — a submit-time decoder that recovers the soroban contract code (catalog `1000/2000/3000` ranges) from a caught colibri contract-error-matcher payload (`meta.data.match.code`, walking the cause chain) or the rendered `Contract error: <Variant>` message, and maps it via the existing `MoonlightContractError` catalog. Returns `null` for non-contract (transient) errors so callers can distinguish deterministic reverts from retryable failures.

This is the single decoder the whole chain uses to turn an opaque thrown error into a stable code that provider-platform persists to `failureDetail` and the API boundary translates to the user (hole #1).

## Tests
`src/error/decode-contract-error.unit.test.ts` (direct match, cause-chain walk, message fallback, network-error null, catalog-drift null). Full suite: 20 passed / 0 failed (incl. testnet integration).

Consumers: only provider-platform imports this new export; it pins `^0.11.1`.