### PR TITLE
ci: run test:unit on merge gate, drop live-Testnet integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         run: deno lint
 
       - name: Run tests
-        run: deno task test
+        run: deno task test:unit
 
       - name: Generate coverage report
         run: deno coverage --lcov coverage > coverage.lcov

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonlight/moonlight-sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A privacy-focused toolkit for the Moonlight protocol on Stellar Soroban smart contracts.",
   "license": "MIT",
   "tasks": {


### PR DESCRIPTION
## What

Change the Test workflow's test step from `deno task test` to `deno task test:unit`, so the merge gate runs only the deterministic unit suite and no longer executes the live-Testnet `*.integration.test.ts` tests on push/PR.

## Why

`deno task test` runs everything, including `*.integration.test.ts` against the live public Stellar Testnet. Those tests depend on real network ops (e.g. uploading contract WASM) that transiently fail — a flaky merge gate that validates the network, not the code. This produced red `Test (push)` runs on `main` (2026-06-17, 2026-06-23: `CONTR_004: Failed to upload WASM to the network`) while the same code passed on retried PR runs.

## Scope

- `.github/workflows/test.yml`: `deno task test` → `deno task test:unit`. Lint and coverage steps unchanged; `test:unit` produces the same `coverage` dir the coverage step consumes.
- `test:integration` task **retained** in `deno.json` for on-demand/manual runs — not deleted or modified.
- `deno.json` patch bump 0.6.1 → 0.6.2.

## Verification (local, deno 2.9.0)

- `deno lint` — clean (89 files).
- `deno task test:unit` — `13 passed (151 steps) | 0 failed (1s)`; zero integration tests executed.
- Coverage step generates `coverage.lcov` from the `test:unit` coverage dir.