### PR TITLE
fix(errors): drop dead ReentrantCall/3008 mapping

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonlight/moonlight-sdk",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "A privacy-focused toolkit for the Moonlight protocol on Stellar Soroban smart contracts.",
   "license": "MIT",
   "tasks": {

--- a/src/error/contract-errors.ts
+++ b/src/error/contract-errors.ts
@@ -149,10 +149,6 @@ export const MoonlightContractError: KnownContractErrorMap = {
     message: "InvalidExternalAmount",
     details: "A deposit or withdraw amount was not strictly positive.",
   },
-  3008: {
-    message: "ReentrantCall",
-    details: "transact was re-entered while a call was already in progress.",
-  },
   4000: {
     message: "NotEd25519AccountAddress",
     details:


### PR DESCRIPTION
## What

Removes the now-dead `3008 -> ReentrantCall` entry from the SDK contract-error catalog (`src/error/contract-errors.ts`).

## Why

soroban-core removed the MOON-06 reentrancy guard (soroban-core#41) — reentrancy is forbidden by Soroban at the platform level — including dropping the `ReentrantCall = 3_008` contract error variant. The SDK's `3008 -> ReentrantCall` mapping is now dead (maps to a code the contract no longer defines). Removing it keeps the SDK error catalog in sync with the contract.

## Changes

- `src/error/contract-errors.ts`: remove the `3008 / ReentrantCall` entry. No other references existed (no imports, re-exports, or tests asserted it).
- `deno.json`: patch bump `0.11.1 -> 0.11.2`.

## Verification

- `grep -rn 'ReentrantCall\|3008' src/` -> clean (no matches).
- `deno fmt --check`, `deno lint`, `deno task test:unit` all green locally.

Base = `main` (where this mapping lives; `dev` uses a different error architecture and never had it).