### PR TITLE
ci: run test:unit on merge gate, drop live-Testnet integration tests (main)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: deno lint
 
       - name: Run tests
-        run: deno task test
+        run: deno task test:unit
 
       - name: Generate coverage report
         run: deno coverage --lcov coverage > coverage.lcov

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonlight/moonlight-sdk",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A privacy-focused toolkit for the Moonlight protocol on Stellar Soroban smart contracts.",
   "license": "MIT",
   "tasks": {


### PR DESCRIPTION
## What

Change the Test workflow's test step from `deno task test` to `deno task test:unit`, so the merge gate runs only the deterministic unit suite and no longer executes the live-Testnet `*.integration.test.ts` tests on push/PR.

This ports the effect of #40 (merged to `dev`) to `main`. `main` and `dev` share the same relevant structure here: the gate runs `deno task test` (everything, including integration), and `main`'s `deno.json` already defines a `test:unit` task that ignores `**/*.integration.test.ts`.

## Why

`deno task test` runs everything, including `*.integration.test.ts` against the live public Stellar Testnet. Those tests depend on real network ops (e.g. uploading contract WASM) that transiently fail — a flaky merge gate that validates the network, not the code.

## Scope

- `.github/workflows/test.yml`: `deno task test` -> `deno task test:unit`. Lint and coverage steps unchanged; `test:unit` produces the same `coverage` dir the coverage step consumes.
- `test:integration` task **retained** in `deno.json` for on-demand/manual runs — not deleted or modified.
- `deno.json` patch bump 0.11.1 -> 0.11.2.

## Verification (local, deno 2.9.0)

- `deno fmt --check` — clean (105 files).
- `deno lint` — clean (96 files).
- `deno task test:unit` — `17 passed (199 steps) | 0 failed`; zero integration tests executed.
- Coverage step generates `coverage.lcov` from the `test:unit` coverage dir.