### PR TITLE
chore: release 0.12.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonlight/moonlight-sdk",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "description": "A privacy-focused toolkit for the Moonlight protocol on Stellar Soroban smart contracts.",
   "license": "MIT",
   "tasks": {


### PR DESCRIPTION
A1 (#44) is a breaking encoding change but its version bump (0.11.4) published inside the ^0.11 caret range. 0.12.0 re-releases it on the correct major line so consumers only pick it up via explicit bumps. 0.11.4 should be yanked on JSR after this lands.